### PR TITLE
fix the lmm predict function to use the correct argument name

### DIFF
--- a/R/linear-mixed-model-deployment.R
+++ b/R/linear-mixed-model-deployment.R
@@ -119,7 +119,7 @@ LinearMixedModelDeployment <- R6Class("LinearMixedModelDeployment",
         print(row(private$dfTest))
 
         private$predictedVals = predict(private$fit,
-                                        data = private$dfTest,
+                                        newdata = private$dfTest,
                                         allow.new.levels = TRUE,
                                         type="response")
         # For unit test


### PR DESCRIPTION
Applying the bug chungsu found in the predict() call for the linear mixed model deployment.
change "data" to "newdata"